### PR TITLE
feat /api/v1/route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ yarn-debug.log*
 .browserslistrc
 
 /.idea
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ gem 'mutex_m'
 # install ffi
 gem 'ffi'
 
+gem 'dotenv-rails'
+
 # gem 'therubyracer', platforms: :ruby
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,10 @@ GEM
     crass (1.0.6)
     date (3.3.4)
     diff-lcs (1.5.1)
+    dotenv (3.1.2)
+    dotenv-rails (3.1.2)
+      dotenv (= 3.1.2)
+      railties (>= 6.1)
     erubi (1.13.0)
     execjs (2.9.1)
     ffi (1.17.0-aarch64-linux-gnu)
@@ -248,6 +252,7 @@ DEPENDENCIES
   base64
   bigdecimal
   bootsnap
+  dotenv-rails
   execjs
   ffi
   mutex_m

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -3,16 +3,21 @@ require 'json'
 
 class Api::V1::RoutesController < ApplicationController
   def index
-    data_arr = params[:_json]
+    if request.post?
+      data_arr = params[:_json]
 
-    from = get_fromstation(data_arr)
-    to = get_tostation(data_arr)
-    inf = {from: from, to: to}
-    if data_arr
-      render json: inf, status: :created
-    else
-      render json: { errors: "error" }, status: :unprocessable_entity
+      from = get_fromstation(data_arr)
+      to = get_tostation(data_arr)
+      inf = {from: from, to: to}
+      if data_arr
+        render json: inf, status: :created
+      else
+        render json: { errors: "error" }, status: :unprocessable_entity
+      end
+    elsif request.get?
+      render json: { errors: "method error" }, status: :bad_request
     end
+
   end
 
   private
@@ -40,6 +45,11 @@ class Api::V1::RoutesController < ApplicationController
     # requestメソッドの引数にNet:HTTP:Responseオブジェクトをあたえます。
     # responseには、HTTPレスポンスが格納されている
     station_data = JSON.parse(response.body)
-    return station_data[0]['odpt:stationTitle']
-  end
+    if station_data.empty?
+      return nil
+      else
+      return station_data[0]['odpt:stationTitle']
+    end
+
+    end
 end

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -1,17 +1,45 @@
+require 'net/http'
+require 'json'
+
 class Api::V1::RoutesController < ApplicationController
   def index
-    post = Route.new(routes_params)
+    data_arr = params[:_json]
 
-    if post.save
-      render json: post, status: :created
+    from = get_fromstation(data_arr)
+    to = get_tostation(data_arr)
+    inf = {from: from, to: to}
+    if data_arr
+      render json: inf, status: :created
     else
-      render json: { errors: post.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: "error" }, status: :unprocessable_entity
     end
   end
 
   private
 
-  def routes_params
-    params.require(:route).permit(:start, :end)
+  def get_fromstation(coordinates)
+    _get_station(coordinates, 0)
+  end
+
+  def get_tostation(coordinates)
+    _get_station(coordinates, -1)
+  end
+
+  def _get_station(coordinates, str)
+    coordinate = coordinates[str]
+    uri = URI.parse('https://api.odpt.org')
+    # URI.parseは、URIオブジェクトを生成するメソッドです。
+    http_client= Net::HTTP.new(uri.host,uri.port)
+    # HTTPクライアントを生成し、引数にホスト名とポート番号を指定しています。
+    get_request = Net::HTTP::Get.new("/api/v4/places/odpt:Station?lon=#{coordinate[:longitude]}&lat=#{coordinate[:latitude]}&radius=100&acl:consumerKey=#{ENV['CONSUMER_KEY']}", 'Content-Type' => 'application/json')
+    # Net::HTTP::Getは、HTTPのGETリクエストを表すクラスです。
+    # 引数にリクエストするpathとヘッダーを指定しています。
+    http_client.use_ssl = true
+    # httpsで通信をする場合はuse_sslをtrueにする必要がある
+    response = http_client.request(get_request)
+    # requestメソッドの引数にNet:HTTP:Responseオブジェクトをあたえます。
+    # responseには、HTTPレスポンスが格納されている
+    station_data = JSON.parse(response.body)
+    return station_data[0]['odpt:stationTitle']
   end
 end

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::RoutesController < ApplicationController
       from = get_fromstation(data_arr)
       to = get_tostation(data_arr)
       inf = {from: from, to: to}
-      if data_arr
+      if inf
         render json: inf, status: :created
       else
         render json: { errors: "error" }, status: :unprocessable_entity
@@ -47,9 +47,8 @@ class Api::V1::RoutesController < ApplicationController
     station_data = JSON.parse(response.body)
     if station_data.empty?
       return nil
-      else
+    else
       return station_data[0]['odpt:stationTitle']
     end
-
-    end
+  end
 end


### PR DESCRIPTION
経路情報``POSTAPI``の作成
リクエスト側
```json
[
  {
    "longitude": 140.11161723614123,
    "latitude": 36.08261207226881
  },
  {
    "longitude": 140.11161723614123,
    "latitude": 36.08261207226881
  }
]
```
返り値
```json
{
  "from": {
    "en": "Tsukuba",
    "ja": "つくば",
    "ko": "츠쿠바",
    "zh-Hans": "筑波",
    "zh-Hant": "筑波"
  },
  "to": {
    "en": "Tsukuba",
    "ja": "つくば",
    "ko": "츠쿠바",
    "zh-Hans": "筑波",
    "zh-Hant": "筑波"
  }
}
```
外部API用に``.env``を作成する必要がある
```.env
CONSUMER_KEY=トークン
```